### PR TITLE
fix: Cname to deploy

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-bastionlab.com.mx


### PR DESCRIPTION
Se elimina el CNAME del raíz, dejando solo el de la carpeta public.